### PR TITLE
Node deployment enhancements

### DIFF
--- a/go.sum
+++ b/go.sum
@@ -183,6 +183,7 @@ github.com/hashicorp/terraform-plugin-sdk v1.4.0 h1:b1LluARpES0Gq78oF4a9of3eS0iX
 github.com/hashicorp/terraform-plugin-sdk v1.4.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
 github.com/hashicorp/terraform-plugin-sdk v1.6.0 h1:Um5hsAL7kKsfTHtan8lybY/d03F2bHu4fjRB1H6Ag4U=
 github.com/hashicorp/terraform-plugin-sdk v1.6.0/go.mod h1:H5QLx/uhwfxBZ59Bc5SqT19M4i+fYt7LZjHTpbLZiAg=
+github.com/hashicorp/terraform-plugin-sdk v1.15.0 h1:bmYnTT7MqNXlUHDc7pT8E6uKT2g/upjlRLypJFK1OQU=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596 h1:hjyO2JsNZUKT1ym+FAdlBEkGPevazYsmVgIMw7dVELg=
 github.com/hashicorp/terraform-svchost v0.0.0-20191011084731-65d371908596/go.mod h1:kNDNcF7sN4DocDLBkQYz73HGKwN1ANB1blq4lIYLYvg=
 github.com/hashicorp/yamux v0.0.0-20180604194846-3520598351bb/go.mod h1:+NfK9FKeTrX5uv1uIXGdwYDTeHna2qgaIlx54MXqjAM=

--- a/kubermatic/provider_test.go
+++ b/kubermatic/provider_test.go
@@ -14,7 +14,8 @@ import (
 const (
 	testNamePrefix = "tf-acc-test-"
 
-	testEnvOtherUserEmail = "KUBERMATIC_ANOTHER_USER_EMAIL"
+	testEnvOtherUserEmail    = "KUBERMATIC_ANOTHER_USER_EMAIL"
+	testEnvExistingClusterID = "KUBERMATIC_EXISTING_CLUSTER_ID"
 
 	testEnvK8sVersion17 = "KUBERMATIC_K8S_VERSION_17"
 	testEnvK8sVersion16 = "KUBERMATIC_K8S_VERSION_16"
@@ -67,6 +68,12 @@ func testAccPreCheckForOpenstack(t *testing.T) {
 	checkEnv(t, testEnvOpenstackImage)
 	checkEnv(t, testEnvOpenstackImage2)
 	checkEnv(t, testEnvOpenstackFlavor)
+}
+
+func testAccPreCheckExistingCluster(t *testing.T) {
+	t.Helper()
+	testAccPreCheck(t)
+	checkEnv(t, testEnvExistingClusterID)
 }
 
 func testAccPreCheckForAzure(t *testing.T) {

--- a/kubermatic/resource_node_deployment.go
+++ b/kubermatic/resource_node_deployment.go
@@ -21,6 +21,7 @@ func resourceNodeDeployment() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
+		CustomizeDiff: validateVersionAgainstCluster(),
 
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {

--- a/kubermatic/resource_node_deployment.go
+++ b/kubermatic/resource_node_deployment.go
@@ -21,7 +21,7 @@ func resourceNodeDeployment() *schema.Resource {
 		Importer: &schema.ResourceImporter{
 			State: schema.ImportStatePassthrough,
 		},
-		CustomizeDiff: validateVersionAgainstCluster(),
+		CustomizeDiff: validateNodeSpecMatchesCluster(),
 
 		Schema: map[string]*schema.Schema{
 			"cluster_id": {

--- a/kubermatic/resource_node_deployment_test.go
+++ b/kubermatic/resource_node_deployment_test.go
@@ -42,6 +42,7 @@ func TestAccKubermaticNodeDeployment_Openstack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.template.0.cloud.0.openstack.0.image", image),
 					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.template.0.operating_system.0.ubuntu.#", "1"),
 					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.template.0.versions.0.kubelet", kubeletVersion16),
+					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.dynamic_config", "false"),
 				),
 			},
 			{
@@ -67,6 +68,7 @@ func TestAccKubermaticNodeDeployment_Openstack_Basic(t *testing.T) {
 					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.template.0.cloud.0.openstack.0.disk_size", "123"),
 					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.template.0.operating_system.0.ubuntu.0.dist_upgrade_on_boot", "true"),
 					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.template.0.versions.0.kubelet", kubeletVersion16),
+					resource.TestCheckResourceAttr("kubermatic_node_deployment.acctest_nd", "spec.0.dynamic_config", "true"),
 				),
 			},
 		},
@@ -152,6 +154,7 @@ func testAccCheckKubermaticNodeDeploymentBasic2(testName, nodeDC, username, pass
 		cluster_id = kubermatic_cluster.acctest_cluster.id
 		name = "%s"
 		spec {
+			dynamic_config = true
 			replicas = 1
 			template {
 				labels = {
@@ -301,6 +304,7 @@ func testAccCheckKubermaticNodeDeploymentAzureBasic(n, clientID, clientSecret, t
 		spec {
 			replicas = 2
 			template {
+				dynamic_config = false
 				cloud {
 					azure {
 						size = "%s"

--- a/kubermatic/schema_node_deployment.go
+++ b/kubermatic/schema_node_deployment.go
@@ -23,6 +23,12 @@ func validateLabelOrTag(key string) error {
 
 func nodeDeploymentSpecFields() map[string]*schema.Schema {
 	return map[string]*schema.Schema{
+		"dynamic_config": {
+			Type:        schema.TypeBool,
+			Optional:    true,
+			Default:     false,
+			Description: "Use kubermatic dynamic config",
+		},
 		"replicas": {
 			Type:        schema.TypeInt,
 			Optional:    true,

--- a/kubermatic/schema_node_deployment.go
+++ b/kubermatic/schema_node_deployment.go
@@ -114,6 +114,7 @@ func nodeDeploymentSpecFields() map[string]*schema.Schema {
 									Description: "Kubelet version",
 								},
 							},
+							CustomizeDiff: validateKubeletVersionExists(),
 						},
 					},
 					"labels": {

--- a/kubermatic/schema_node_deployment.go
+++ b/kubermatic/schema_node_deployment.go
@@ -114,7 +114,6 @@ func nodeDeploymentSpecFields() map[string]*schema.Schema {
 									Description: "Kubelet version",
 								},
 							},
-							CustomizeDiff: validateKubeletVersionExists(),
 						},
 					},
 					"labels": {

--- a/kubermatic/structure_node_deployment.go
+++ b/kubermatic/structure_node_deployment.go
@@ -20,6 +20,8 @@ func flattenNodeDeploymentSpec(values *nodeSpecPreservedValues, in *models.NodeD
 		att["template"] = flattenNodeSpec(values, in.Template)
 	}
 
+	att["dynamic_config"] = in.DynamicConfig
+
 	return []interface{}{att}
 }
 
@@ -303,6 +305,10 @@ func expandNodeDeploymentSpec(p []interface{}) *models.NodeDeploymentSpec {
 
 	if v, ok := in["template"]; ok {
 		obj.Template = expandNodeSpec(v.([]interface{}))
+	}
+
+	if v, ok := in["dynamic_config"]; ok {
+		obj.DynamicConfig = v.(bool)
 	}
 
 	return obj

--- a/kubermatic/structure_node_deployment_test.go
+++ b/kubermatic/structure_node_deployment_test.go
@@ -14,20 +14,22 @@ func TestFlattenNodeDeploymentSpec(t *testing.T) {
 	}{
 		{
 			&models.NodeDeploymentSpec{
-				Replicas: int32ToPtr(1),
-				Template: &models.NodeSpec{},
+				Replicas:      int32ToPtr(1),
+				Template:      &models.NodeSpec{},
+				DynamicConfig: true,
 			},
 			[]interface{}{
 				map[string]interface{}{
-					"replicas": int32(1),
-					"template": []interface{}{map[string]interface{}{}},
+					"replicas":       int32(1),
+					"template":       []interface{}{map[string]interface{}{}},
+					"dynamic_config": true,
 				},
 			},
 		},
 		{
 			&models.NodeDeploymentSpec{},
 			[]interface{}{
-				map[string]interface{}{},
+				map[string]interface{}{"dynamic_config": false},
 			},
 		},
 		{
@@ -324,13 +326,15 @@ func TestExpandNodeDeploymentSpec(t *testing.T) {
 		{
 			[]interface{}{
 				map[string]interface{}{
-					"replicas": 1,
-					"template": []interface{}{map[string]interface{}{}},
+					"replicas":       1,
+					"template":       []interface{}{map[string]interface{}{}},
+					"dynamic_config": true,
 				},
 			},
 			&models.NodeDeploymentSpec{
-				Replicas: int32ToPtr(1),
-				Template: &models.NodeSpec{},
+				Replicas:      int32ToPtr(1),
+				Template:      &models.NodeSpec{},
+				DynamicConfig: true,
 			},
 		},
 		{

--- a/kubermatic/validation_node_deployment.go
+++ b/kubermatic/validation_node_deployment.go
@@ -49,6 +49,8 @@ func getClusterCloudProvider(c *models.Cluster) (string, error) {
 		return "aws", nil
 	case c.Spec.Cloud.Openstack != nil:
 		return "openstack", nil
+	case c.Spec.Cloud.Azure != nil:
+		return "azure", nil
 	default:
 		return "", fmt.Errorf("could not find cloud provider for cluster")
 
@@ -56,7 +58,7 @@ func getClusterCloudProvider(c *models.Cluster) (string, error) {
 }
 
 func validateProviderMatchesCluster(d *schema.ResourceDiff, clusterProvider string) error {
-	var availableProviders = []string{"bringyourown", "aws", "openstack"}
+	var availableProviders = []string{"bringyourown", "aws", "openstack", "azure"}
 	var provider string
 
 	for _, p := range availableProviders {

--- a/kubermatic/validation_node_deployment.go
+++ b/kubermatic/validation_node_deployment.go
@@ -7,32 +7,28 @@ import (
 	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
 	"github.com/kubermatic/go-kubermatic/client/project"
 	"github.com/kubermatic/go-kubermatic/client/versions"
+	"github.com/kubermatic/go-kubermatic/models"
 )
 
-func getClusterForNodeDeployment(id string, k *kubermaticProviderMeta) (*models.Cluster, error) {
-	projectID, seedDC, clusterID, err := kubermaticClusterParseID(id)
-	if err != nil {
-		return nil, err
+func validateNodeSpecMatchesCluster() schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		cluster, err := getClusterForNodeDeployment(d.Get("cluster_id").(string), meta.(*kubermaticProviderMeta))
+		if err != nil {
+			return err
+		}
+		err = validateVersionAgainstCluster(d, cluster)
+		if err != nil {
+			return err
+		}
+		err = validateProviderMatchesCluster(d, cluster)
+		if err != nil {
+			return err
+		}
+		return nil
 	}
-
-	p := project.NewGetClusterParams()
-	p.SetProjectID(projectID)
-	p.SetDC(seedDC)
-	p.SetClusterID(clusterID)
-	r, err := k.client.Project.GetCluster(p, k.auth)
-	if err != nil {
-		return nil, fmt.Errorf("unable to get cluster %s in project %s in seed dc %s - error: %v", clusterID, projectID, seedDC, err)
-	}
-
-	return r.Payload, nil
 }
 
-func getClusterVersion(id string, k *kubermaticProviderMeta) (*version.Version, error) {
-	cluster, err := getClusterForNodeDeployment(id, k)
-	if err != nil {
-		return nil, err
-	}
-
+func getClusterVersion(cluster *models.Cluster) (*version.Version, error) {
 	v, err := version.NewVersion(cluster.Spec.Version.(string))
 	if err != nil {
 		return nil, err
@@ -40,29 +36,64 @@ func getClusterVersion(id string, k *kubermaticProviderMeta) (*version.Version, 
 	return v, nil
 }
 
-func validateVersionAgainstCluster() schema.CustomizeDiffFunc {
-	return func(d *schema.ResourceDiff, meta interface{}) error {
-		dataVersion, ok := d.Get("spec.0.template.0.versions.0.kubelet").(string)
-		if dataVersion == "" || !ok {
-			return nil
-		}
+func getClusterCloudProvider(c *models.Cluster) (string, error) {
+	switch {
+	case c.Spec.Cloud.Bringyourown != nil:
+		return "bringyourown", nil
+	case c.Spec.Cloud.Aws != nil:
+		return "aws", nil
+	case c.Spec.Cloud.Openstack != nil:
+		return "openstack", nil
+	default:
+		return "", fmt.Errorf("could not find cloud provider for cluster")
 
-		v, err := version.NewVersion(dataVersion)
+	}
+}
 
-		if err != nil {
-			return fmt.Errorf("unable to parse node deployment version")
-		}
+func validateProviderMatchesCluster(d *schema.ResourceDiff, c *models.Cluster) error {
+	var availableProviders = []string{"bringyourown", "aws", "openstack"}
+	var provider string
 
-		clusterVersion, err := getClusterVersion(d.Get("cluster_id").(string), meta.(*kubermaticProviderMeta))
-		if err != nil {
-			return err
+	for _, p := range availableProviders {
+		providerField := fmt.Sprintf("spec.0.template.0.cloud.0.%s", p)
+		_, ok := d.GetOk(providerField)
+		if ok {
+			provider = p
+			break
 		}
+	}
+	clusterProvider, err := getClusterCloudProvider(c)
+	if err != nil {
+		return err
+	}
+	if provider != clusterProvider {
+		return fmt.Errorf("provider for node deployment must (%s) match cluster provider (%s)", provider, clusterProvider)
+	}
+	return nil
 
-		if clusterVersion.LessThan(v) {
-			return fmt.Errorf("node deployment version (%s) cannot be greater than cluster version (%s)", v, clusterVersion)
-		}
+}
+
+func validateVersionAgainstCluster(d *schema.ResourceDiff, c *models.Cluster) error {
+	dataVersion, ok := d.Get("spec.0.template.0.versions.0.kubelet").(string)
+	if dataVersion == "" || !ok {
 		return nil
 	}
+
+	v, err := version.NewVersion(dataVersion)
+
+	if err != nil {
+		return fmt.Errorf("unable to parse node deployment version")
+	}
+
+	clusterVersion, err := getClusterVersion(c)
+	if err != nil {
+		return err
+	}
+
+	if clusterVersion.LessThan(v) {
+		return fmt.Errorf("node deployment version (%s) cannot be greater than cluster version (%s)", v, clusterVersion)
+	}
+	return nil
 }
 
 func validateKubeletVersionExists() schema.CustomizeDiffFunc {
@@ -89,4 +120,22 @@ func validateKubeletVersionExists() schema.CustomizeDiffFunc {
 
 		return fmt.Errorf("unknown version %s", version)
 	}
+}
+
+func getClusterForNodeDeployment(id string, k *kubermaticProviderMeta) (*models.Cluster, error) {
+	projectID, seedDC, clusterID, err := kubermaticClusterParseID(id)
+	if err != nil {
+		return nil, err
+	}
+
+	p := project.NewGetClusterParams()
+	p.SetProjectID(projectID)
+	p.SetDC(seedDC)
+	p.SetClusterID(clusterID)
+	r, err := k.client.Project.GetCluster(p, k.auth)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get cluster %s in project %s in seed dc %s - error: %v", clusterID, projectID, seedDC, err)
+	}
+
+	return r.Payload, nil
 }

--- a/kubermatic/validation_node_deployment.go
+++ b/kubermatic/validation_node_deployment.go
@@ -33,13 +33,18 @@ func getClusterVersion(id string, k *kubermaticProviderMeta) (*version.Version, 
 
 func validateVersionAgainstCluster() schema.CustomizeDiffFunc {
 	return func(d *schema.ResourceDiff, meta interface{}) error {
-		k := meta.(*kubermaticProviderMeta)
-		v, err := version.NewVersion(d.Get("spec.0.template.0.versions.0.kubelet").(string))
+		dataVersion, ok := d.Get("spec.0.template.0.versions.0.kubelet").(string)
+		if dataVersion == "" || !ok {
+			return nil
+		}
+
+		v, err := version.NewVersion(dataVersion)
+
 		if err != nil {
 			return fmt.Errorf("unable to parse node deployment version")
 		}
 
-		clusterVersion, err := getClusterVersion(d.Get("cluster_id").(string), k)
+		clusterVersion, err := getClusterVersion(d.Get("cluster_id").(string), meta.(*kubermaticProviderMeta))
 		if err != nil {
 			return err
 		}

--- a/kubermatic/validation_node_deployment.go
+++ b/kubermatic/validation_node_deployment.go
@@ -1,0 +1,34 @@
+package kubermatic
+
+import (
+	"fmt"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/schema"
+	"github.com/kubermatic/go-kubermatic/client/versions"
+)
+
+func validateKubeletVersionExists() schema.CustomizeDiffFunc {
+	return func(d *schema.ResourceDiff, meta interface{}) error {
+		k := meta.(*kubermaticProviderMeta)
+		version := d.Get("kubelet").(string)
+		versionType := "kubernetes"
+		p := versions.NewGetNodeUpgradesParams()
+		p.SetType(&versionType)
+		p.SetControlPlaneVersion(&version)
+		r, err := k.client.Versions.GetNodeUpgrades(p, k.auth)
+		if err != nil {
+			if e, ok := err.(*versions.GetNodeUpgradesDefault); ok && e.Payload != nil && e.Payload.Error != nil && e.Payload.Error.Message != nil {
+				return fmt.Errorf("get node_deployment upgrades: %s", *e.Payload.Error.Message)
+			}
+			return err
+		}
+
+		for _, v := range r.Payload {
+			if s, ok := v.Version.(string); ok && s == version {
+				return nil
+			}
+		}
+
+		return fmt.Errorf("unknown version %s", version)
+	}
+}

--- a/kubermatic/validation_node_deployment.go
+++ b/kubermatic/validation_node_deployment.go
@@ -13,7 +13,11 @@ import (
 func validateNodeSpecMatchesCluster() schema.CustomizeDiffFunc {
 	return func(d *schema.ResourceDiff, meta interface{}) error {
 		k := meta.(*kubermaticProviderMeta)
-		cluster, err := getClusterForNodeDeployment(d.Get("cluster_id").(string), k)
+		clusterID := d.Get("cluster_id").(string)
+		if clusterID == "" {
+			return nil
+		}
+		cluster, err := getClusterForNodeDeployment(clusterID, k)
 		if err != nil {
 			return err
 		}

--- a/kubermatic/validation_node_deployment_test.go
+++ b/kubermatic/validation_node_deployment_test.go
@@ -1,0 +1,91 @@
+package kubermatic
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+	"testing"
+
+	"github.com/hashicorp/terraform-plugin-sdk/helper/resource"
+)
+
+func TestAccKubermaticNodeDeployment_ValidationAgainstCluster(t *testing.T) {
+	testName := randomTestName()
+
+	username := os.Getenv(testEnvOpenstackUsername)
+	password := os.Getenv(testEnvOpenstackPassword)
+	tenant := os.Getenv(testEnvOpenstackTenant)
+	nodeDC := os.Getenv(testEnvOpenstackNodeDC)
+	image := os.Getenv(testEnvOpenstackImage)
+	flavor := os.Getenv(testEnvOpenstackFlavor)
+
+	k8sVersion17 := os.Getenv(testEnvK8sVersion17)
+	kubeletVersion16 := os.Getenv(testEnvK8sVersion16)
+	unavailableVersion := "1.12.1"
+	bigVersion := "3.0.0"
+
+	existingClusterID := os.Getenv(testEnvExistingClusterID)
+
+	azure := `
+		azure {
+		size = "2"
+	}`
+	openstack := fmt.Sprintf(`
+		openstack {
+	  		flavor = "%s"
+	  		image = "%s"
+		  }`, flavor, image)
+
+	resource.Test(t, resource.TestCase{
+		PreCheck: func() {
+			testAccPreCheckForOpenstack(t)
+			testAccPreCheckExistingCluster(t)
+		},
+		Providers:    testAccProviders,
+		CheckDestroy: testAccCheckKubermaticNodeDeploymentDestroy,
+		Steps: []resource.TestStep{
+			{
+				PlanOnly:           true,
+				Config:             testAccCheckKubermaticNodeDeploymentBasic(testName, nodeDC, username, password, tenant, k8sVersion17, kubeletVersion16, image, flavor),
+				ExpectNonEmptyPlan: true,
+			},
+			{
+				PlanOnly:    true,
+				Config:      testAccCheckKubermaticNodeDeploymentBasicValidation(existingClusterID, testName, kubeletVersion16, azure),
+				ExpectError: regexp.MustCompile(`provider for node deployment must \(.*\) match cluster provider \(.*\)`),
+			},
+			{
+				PlanOnly:    true,
+				Config:      testAccCheckKubermaticNodeDeploymentBasicValidation(existingClusterID, testName, bigVersion, azure),
+				ExpectError: regexp.MustCompile(`cannot be greater than cluster version`),
+			},
+			{
+				PlanOnly:    true,
+				Config:      testAccCheckKubermaticNodeDeploymentBasicValidation(existingClusterID, testName, unavailableVersion, openstack),
+				ExpectError: regexp.MustCompile(fmt.Sprintf(`unknown version for node deployment %s, available versions`, unavailableVersion)),
+			},
+		},
+	})
+}
+
+func testAccCheckKubermaticNodeDeploymentBasicValidation(clusterID, testName, kubeletVersion, provider string) string {
+	return fmt.Sprintf(`
+	resource "kubermatic_node_deployment" "acctest_nd" {
+		cluster_id = "%s"
+		name = "%s"
+		spec {
+			replicas = 1
+			template {
+				cloud {
+					%s
+				}
+				operating_system {
+					ubuntu {}
+				}
+				versions {
+					kubelet = "%s"
+				}
+			}
+		}
+	}`, clusterID, testName, provider, kubeletVersion)
+}


### PR DESCRIPTION
This PR adds enchancements for the *node deployment* resource.
- validate node version against API endpoint `/upgrades/node/`
- validate node deployment version against cluster version: node version should not be greater than cluster's current version.
- validate if node is being deployed to the same cloud provider as the cluster.

### TODO:
- [x] fix acceptance tests for current valid versions.
- [ ] add acceptance tests with plan only to test validation errors.
- [ ] add `dynamic_config` field to `node_deployment.spec`.
 
PS: I'm not adding to kubermatic/terraform-provider-kubermatic because my branch is up-to date with this repository.